### PR TITLE
Fix glyph used for go

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -168,7 +168,7 @@ function! s:setDictionaries()
 		\	'cljs'     : '',
 		\	'edn'      : '',
 		\	'scala'    : '',
-		\	'go'       : '',
+		\	'go'       : '',
 		\	'dart'     : '',
 		\	'xul'      : '',
 		\	'sln'      : '',


### PR DESCRIPTION
I'm using Sauce Code Powerline Plus Nerd File Types, and just noticed that the Gopher disappeared. I installed the latest font from https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/SourceCodePro, and still got the generic icon, so I updated plugin/webdevicons.vim to use U+E724. That's the change below.