### PR TITLE
Use setlocal so as to not blow away user's config

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -266,8 +266,8 @@ function! s:setSyntax()
       au!
       autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\]" contained conceal containedin=ALL
       autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\[" contained conceal containedin=ALL
-      autocmd FileType nerdtree set conceallevel=3
-      autocmd FileType nerdtree set concealcursor=nvic
+      autocmd FileType nerdtree setlocal conceallevel=3
+      autocmd FileType nerdtree setlocal concealcursor=nvic
     augroup END
   endif
 endfunction


### PR DESCRIPTION
Currently if you open up a directory in NERDtree with webdevicons before opening a file with conceal syntax, if the user has custom concealcursor/conceallevel settings they will be blown away by webdevicons