### PR TITLE
Add slim support

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -127,6 +127,7 @@ function! s:setDictionaries()
 		\	'scss'     : '',
 		\	'htm'      : '',
 		\	'html'     : '',
+		\	'slim'     : '',
 		\	'css'      : '',
 		\	'less'     : '',
 		\	'md'       : '',


### PR DESCRIPTION
Hi @ryanoasis 

Some railers uses slim as default html template engine. This files ended with `.slim`, so i put slim in html icon as default. Hope you like it.