### PR TITLE
Add .markdown support

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -131,6 +131,7 @@ function! s:setDictionaries()
 		\	'css'      : '',
 		\	'less'     : '',
 		\	'md'       : '',
+		\	'markdown' : '',
 		\	'json'     : '',
 		\	'js'       : '',
 		\	'jsx'      : '',


### PR DESCRIPTION
Hi @ryanoasis 

Sorry for many PRs :sunglasses: 

Anyway, some libs like Octopress use `.markdown` extensions instead of `.md`. 
So, thats it. Hope you like. :+1: 