### PR TITLE
Add in system detect for fileformat on current macs

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -599,11 +599,16 @@ endfunction
 " scope: public
 function! WebDevIconsGetFileFormatSymbol(...)
   let fileformat = ""
+  let operatingsystem = system("uname -s")
 
   if &fileformat == "dos"
     let fileformat = ""
   elseif &fileformat == "unix"
-    let fileformat = ""
+    if operatingsystem == "Darwin\n"
+      let fileformat = ""
+    else
+      let fileformat = ""
+    endif
   elseif &fileformat == "mac"
     let fileformat = ""
   endif


### PR DESCRIPTION
Mac OS X and above are designated with only `unix`