### PR TITLE
use a non-deprecated font path for Linux fonts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,8 @@ You basically have to put any font you would like to use into the `~/.fonts` fol
 
 Linux
 ```sh
-cd ~/.fonts && curl -fLo DroidSansMonoForPowerlinePlusNerdFileTypes.otf https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/patched-fonts/DroidSansMono/Droid%20Sans%20Mono%20for%20Powerline%20Plus%20Nerd%20File%20Types.otf
+mkdir -p ~/.local/share/fonts
+cd ~/.local/share/fonts && curl -fLo DroidSansMonoForPowerlinePlusNerdFileTypes.otf https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/patched-fonts/DroidSansMono/Droid%20Sans%20Mono%20for%20Powerline%20Plus%20Nerd%20File%20Types.otf
 ```
 
 OS X


### PR DESCRIPTION
~/.fonts has been deprecated for some time now, in favor of $XDG_DATA_HOME/fonts