### PR TITLE
Detect Darwin with lighter method

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -4,7 +4,6 @@
 " License: see LICENSE
 
 let s:version = '0.7.1'
-let s:operatingsystem = system("uname -s")
 
 " standard fix/safety: line continuation (avoiding side effects) {{{1
 "========================================================================
@@ -136,6 +135,36 @@ endif
 
 " local functions {{{2
 "========================================================================
+
+" scope: local
+function s:isDarwin()
+  if exists('s:is_darwin')
+    return s:is_darwin
+  endif
+
+  if exists('g:WebDevIconsOS')
+    let s:is_darwin = g:WebDevIconsOS ==? 'Darwin'
+    return s:is_darwin
+  endif
+
+  if has('macunix')
+    let s:is_darwin = 1
+    return s:is_darwin
+  endif
+
+  if ! has('unix')
+    let s:is_darwin = 0
+    return s:is_darwin
+  endif
+
+  if system('uname -s') ==# "Darwin\n"
+    let s:is_darwin = 1
+  else
+    let s:is_darwin = 0
+  endif
+
+  return s:is_darwin
+endfunction
 
 " scope: local
 function! s:strip(input)
@@ -534,7 +563,7 @@ function! WebDevIconsGetFileFormatSymbol(...)
   if &fileformat == "dos"
     let fileformat = ""
   elseif &fileformat == "unix"
-    if s:operatingsystem == "Darwin\n"
+    if s:isDarwin()
       let fileformat = ""
     else
       let fileformat = ""

--- a/readme.md
+++ b/readme.md
@@ -413,6 +413,12 @@ let g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols = {} " needed
 let g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols['myext'] = 'ƛ'
   ```
 
+* specify OS to decide an icon for unix fileformat (_not_ defined by default)
+  - this is useful for avoiding unnecessary `system()` call. you might see [#135](https://github.com/ryanoasis/vim-devicons/pull/135) to know logic further.
+ ```vim
+let g:WebDevIconsOS = 'Darwin'
+  ```
+
 ## Lightline Setup
 
 To add the appropriate icon to [lightline](https://github.com/itchyny/lightline.vim), call the function `WebDevIconsGetFileTypeSymbol()` and/or `WebDevIconsGetFileFormatSymbol()` in your `.vimrc`. For example, you could set your sections to:


### PR DESCRIPTION
The plugin is detecting Darwin by system `uname` command. But the `system()` call is too slow, and I noticed it makes the starting method slow, also. In this PR, `has('macunix')` is used for detecting Darwin instead of `system()` call.

You can see this with `+profile` feature.

```sh
vim --cmd "profile start profile.txt" --cmd "profile file /path/to/plugin/webdevicons.vim" +q && vim profile.txt
```

```vim
SCRIPT  /path/to/plugin/webdevicons.vim
Sourced 1 time
Total time:   0.286557
 Self time:   0.001238

count  total (s)   self (s)
                            " Version: 0.7.0
                            " Webpage: https://github.com/ryanoasis/vim-devicons
                            " Maintainer: Ryan McIntyre <ryanoasis@gmail.com>
                            " License: see LICENSE
                            
    1              0.000003 let s:version = '0.7.0'
    1   0.284813   0.000301 let s:operatingsystem = system("uname -s")
                            
                            " standard fix/safety: line continuation (avoiding side effects) {{{1
                            "========================================================================

...
```

* Mac OS X 10.11.2
* Vim 7.4.972 (MacVim snapshot 87)

Vim took 0.286557 second with its loading, and `system("uname -s")` occupied most of it, 0.284813 second.