### PR TITLE
Fix NERDTree-C

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -75,7 +75,7 @@ endfunction
 " NERDTree-C
 " scope: global
 function! WebDevIconsNERDTreeChangeRootHandler(node)
-  call a:node.makeRoot()
+  call b:NERDTree.changeRoot(a:node)
   call NERDTreeRender()
   call a:node.putCursorHere(0, 0)
   redraw!


### PR DESCRIPTION
NERDTree was returning an error when change root node because TreeFileNode.makeRoot() has been changed to NERDTree.changeRoot(node). 