### PR TITLE
Update React (jsx) filetype icon

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -187,7 +187,7 @@ function! s:setDictionaries()
 		\	'markdown' : '',
 		\	'json'     : '',
 		\	'js'       : '',
-		\	'jsx'      : '',
+		\	'jsx'      : '',
 		\	'rb'       : '',
 		\	'php'      : '',
 		\	'py'       : '',


### PR DESCRIPTION
I have changed javascript.jsx file type to get [React](https://facebook.github.io/react/) icon, actually its hard to see icon for small font size but beneficial to select which file is js or jsx from buffer.