### PR TITLE
WebDevIconsGetFileTypeSymbol: break if pattern matches

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -575,6 +575,7 @@ function! WebDevIconsGetFileTypeSymbol(...)
     for [pattern, glyph] in items(g:WebDevIconsUnicodeDecorateFileNodesPatternSymbols)
       if match(fileNode, pattern) != -1
         let symbol = glyph
+        break
       endif
     endfor
 


### PR DESCRIPTION
Not really critical, but I've just noticed it.