### PR TITLE
add reference to tiagofumo/vim-nerdtree-syntax-highlight on readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -578,6 +578,7 @@ WebDevIconsGetFileFormatSymbol()
 
 * How did you get color matching based on file type in nerdtree?
   * my current settings are from: https://github.com/scrooloose/nerdtree/issues/201#issuecomment-9954740
+  * you can add [this](https://github.com/tiagofumo/vim-nerdtree-syntax-highlight) extension created by [@tiagofumo](https://github.com/tiagofumo)
 
 	```vim
 	" NERDTress File highlighting
@@ -612,6 +613,8 @@ WebDevIconsGetFileFormatSymbol()
 	per: https://github.com/ryanoasis/vim-devicons/issues/49#issuecomment-101753558
 
 * How did you get color matching on just the glyph/icon in nerdtree?
+  * you can add [this](https://github.com/tiagofumo/vim-nerdtree-syntax-highlight) extension created by [@tiagofumo](https://github.com/tiagofumo)
+
 	```vim
 	" NERDTress File highlighting only the glyph/icon
 	" test highlight just the glyph (icons) in nerdtree:


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
adds reference to tiagofumo/vim-nerdtree-syntax-highlight on readme as talked with @ryanoasis on gitter

#### How should this be manually tested?
it's a readme file

#### Any background context you can provide?
I created this extension in another repo (because I thought I was going to be the only human being using it) and some people started caring about it, so I asked @ryanoasis if I should add reference to it on the readme's section and he said yes

#### What are the relevant tickets (if any)?
https://github.com/ryanoasis/vim-devicons/issues/158#issuecomment-233814240

#### Screenshots (if appropriate or helpful)
it's possible to see the output on my fork's page: https://github.com/tiagofumo/vim-devicons