### PR TITLE
Do not update when a special buffer is selected

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -369,12 +369,21 @@ function! s:CursorHoldUpdate()
     return
   endif
 
+  " Do not update when a special buffer is selected
+  if !empty(&l:buftype)
+    return
+  endif
+
   " winnr need to make focus go to opened file
   " CursorToTreeWin needed to avoid error on opening file
   let l:winnr = winnr()
+  let l:altwinnr = winnr('#')
+
   call g:NERDTree.CursorToTreeWin()
   call b:NERDTree.root.refreshFlags()
   call NERDTreeRender()
+
+  exec l.altwinnr . 'wincmd w'
   exec l:winnr . 'wincmd w'
 endfunction
 


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

The word “special” in the title, in this case means anything else that a normal buffer (a file). Additionally make sure we reset the alternate window as well so we can keep using that as expected.

For details why this fix is needed, please see this issue https://github.com/ctrlpvim/ctrlp.vim/issues/235 and the comments (mainly the last 5 or so) of this PR https://github.com/ctrlpvim/ctrlp.vim/pull/303

Also please see https://github.com/Xuyuanp/nerdtree-git-plugin/pull/63 as the related code was copied from there and they just merged the same fix as well. So this PR implements that same fix as users have reported the same issue when using this plugin as well.