### PR TITLE
get rid of space after icon in airline

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/webdevicons.vim
+++ b/autoload/airline/extensions/tabline/formatters/webdevicons.vim
@@ -6,7 +6,7 @@
 function! airline#extensions#tabline#formatters#webdevicons#format(bufnr, buffers)
   " Call original formatter.
   let originalFormatter = airline#extensions#tabline#formatters#{g:_webdevicons_airline_orig_formatter}#format(a:bufnr, a:buffers)
-  return originalFormatter . ' ' . WebDevIconsGetFileTypeSymbol(bufname(a:bufnr)) . ' '
+  return originalFormatter . ' ' . WebDevIconsGetFileTypeSymbol(bufname(a:bufnr))
 endfunction
 
 " modeline syntax:


### PR DESCRIPTION
#### Requirements (please check off with 'x')
- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)
#### What does this Pull Request (PR) do?

Gets rid of the extra space after an icon in airline.
#### Any background context you can provide?

There's an extra space after an icon in Airline that results in two spaces being added to the end of a tab title. There's only supposed to be one space there.
