### PR TITLE
fix ctrlp buffer name

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -495,7 +495,7 @@ function! s:initializeCtrlP()
     if l:forkedCtrlp
       if !exists('g:ctrlp_formatline_func')
         " logic for ctrlpvim/ctrlp.vim:
-        let g:ctrlp_formatline_func = 's:formatline(WebDevIconsGetFileTypeSymbol(v:val) . " " . v:val)'
+        let g:ctrlp_formatline_func = 's:formatline(s:curtype() == "buf" ? v:val : WebDevIconsGetFileTypeSymbol(v:val) . " " . v:val) '
       endif
     elseif empty(glob(l:ctrlp_warned_file))
       " logic for kien/ctrlp.vim:


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Fix CtrlPBuffer name is [no named]

#### How should this be manually tested?

Install ctrlp + vimdevicon. Open multiple files. Open CtrlPBuffer

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
#183 
#### Screenshots (if appropriate or helpful)

