### PR TITLE
Handle non-existing g:NERDTree in s:CursorHoldUpdate

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -365,7 +365,7 @@ function! s:CursorHoldUpdate()
     return
   endif
 
-  if !g:NERDTree.IsOpen()
+  if !exists('g:NERDTree') || !g:NERDTree.IsOpen()
     return
   endif
 


### PR DESCRIPTION
I have seen errors there when using `:set verbose=9 | set vfile=/tmp/vfile`.