### PR TITLE
add symbol for byte order marker (utf-8)

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -125,6 +125,10 @@ if !exists('g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol')
   let g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol = ''
 endif
 
+if !exists('g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol')
+  let g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol = ''
+endif
+
 if !exists('g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol')
   if g:DevIconsEnableFoldersOpenClose
     " use new glyph
@@ -607,6 +611,11 @@ endfunction
 " scope: public
 function! WebDevIconsGetFileFormatSymbol(...)
   let fileformat = ''
+  let bomb = ''
+
+  if (&bomb && g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol !=? '')
+    let bomb = g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol . ' '
+  endif
 
   if &fileformat ==? 'dos'
     let fileformat = ''
@@ -624,7 +633,7 @@ function! WebDevIconsGetFileFormatSymbol(...)
   " actual font patcher)
   let artifactFix = "\u00A0"
 
-  return fileformat . artifactFix
+  return bomb . fileformat . artifactFix
 endfunction
 
 " for airline plugin {{{3


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Add the possibility to define a symbol to be displayed IF an utf-8 file contains a byte order marker (BOM)

#### How should this be manually tested?

- add
`let g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol = 'X'`
to your vimrc

- open any utf-8 file. If it has a bom, the X will show. If not:
`:set bomb`

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

![byteordermarker](https://cloud.githubusercontent.com/assets/1249745/24199873/7c70b85c-0f0b-11e7-91be-ec1662f2ba36.png)
The symbol used here is  /uE287
