### PR TITLE
added several glyph to filename/type mappings

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -299,7 +299,8 @@ function! s:setDictionaries()
         \ '.*require.*\.js$'      : '',
         \ '.*materialize.*\.js$'  : '',
         \ '.*materialize.*\.css$' : '',
-        \ '.*mootools.*\.js$'     : ''
+        \ '.*mootools.*\.js$'     : '',
+        \ 'Vagrantfile$'          : ''
         \}
 
   if !exists('g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols')

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -264,7 +264,8 @@ function! s:setDictionaries()
         \ 'psd'      : '',
         \ 'psb'      : '',
         \ 'ts'       : '',
-        \ 'jl'       : ''
+        \ 'jl'       : '',
+        \ 'pp'       : ''
         \}
 
   let s:file_node_exact_matches = {

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -281,6 +281,8 @@ function! s:setDictionaries()
         \ '.gitconfig'                       : '',
         \ '.gitignore'                       : '',
         \ '.bashrc'                          : '',
+        \ '.zshrc'                           : '',
+        \ '.vimrc'                           : '',
         \ '.bashprofile'                     : '',
         \ 'favicon.ico'                      : '',
         \ 'license'                          : '',


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

- [x] adds mapping for `.zshrc` 
- [x] adds mapping for `.vimrc` 
- [x] adds mapping for `.pp` puppet classes 
- [x] adds mapping for `Vagrantfile` 
