### PR TITLE
.sass

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -193,6 +193,7 @@ function! s:setDictionaries()
 
   let s:file_node_extensions = {
         \ 'styl'     : '',
+        \ 'sass'     : '',
         \ 'scss'     : '',
         \ 'htm'      : '',
         \ 'html'     : '',

--- a/readme.md
+++ b/readme.md
@@ -277,7 +277,7 @@ Detailed Features
 * Customizable and extendable glyphs (icons) settings
   * ability to override defaults and use your own characters or glyphs
 * Supports a wide range of file type extensions by default:
-  * ```styl, scss, htm, html, slim, ejs, css, less, md, rmd, json, js, jsx, rb, php, py, pyc, pyd, pyo, coffee, mustache, hbs, conf, ini, yml, bat, jpg, jpeg, bmp, png, gif, twig, cpp, c++, cxx, cc, cp, c, h, hpp, hxx, hs, lhs, lua, java, sh, bash, zsh, ksh, csh, awk, ps1, fish, diff, db, clj, cljs, edn, scala, go, dart, xul, sln, suo, pl, pm, t, rss, f#, fsscript, fsx, fs, fsi, rs, rlib, d, erl, hrl, vim, ai, psd, psb, ts, jl, pp```
+  * ```styl, sass, scss, htm, html, slim, ejs, css, less, md, rmd, json, js, jsx, rb, php, py, pyc, pyd, pyo, coffee, mustache, hbs, conf, ini, yml, bat, jpg, jpeg, bmp, png, gif, twig, cpp, c++, cxx, cc, cp, c, h, hpp, hxx, hs, lhs, lua, java, sh, bash, zsh, ksh, csh, awk, ps1, fish, diff, db, clj, cljs, edn, scala, go, dart, xul, sln, suo, pl, pm, t, rss, f#, fsscript, fsx, fs, fsi, rs, rlib, d, erl, hrl, vim, ai, psd, psb, ts, jl, pp```
 * Supports a few full filename matches, by default:
   * ```gruntfile.coffee, gruntfile.js, gruntfile.ls, gulpfile.coffee, gulpfile.js, gulpfile.ls, dropbox, .ds_store, .gitconfig, .gitignore, .bashrc, .zshrc, .vimrc, .bashprofile, favicon.ico, license, node_modules, react.jsx, procfile```
 * Supports a few library pattern matches, by default:


### PR DESCRIPTION
`.sass` and `.scss` are both Sass. `.sass` is the indented syntax.

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Add support for extension whose icon that already exists.

#### How should this be manually tested?
Load as `.sass` file

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
