### PR TITLE
Add `vim-workspace` as an integrated plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Features
 
 **VimDevIcons integrates with these plugins and more:**
 
-[NERDTree] | [vim-airline] | [CtrlP][ctrlpvim-CtrlP] | [powerline] | [Denite] | [unite] | [lightline.vim] | [vim-startify] | [vimfiler] | [flagship]
+[NERDTree] | [vim-airline] | [CtrlP][ctrlpvim-CtrlP] | [powerline] | [Denite] | [unite] | [lightline.vim] | [vim-startify] | [vimfiler] | [flagship] | [vim-workspace]
 
 * Customizable and extendable glyphs (icons) settings
   * ability to override defaults and use your own characters or glyphs
@@ -612,6 +612,7 @@ Link References
 [ctrlpvim-CtrlP]:https://github.com/ctrlpvim/ctrlp.vim
 [powerline]:https://github.com/powerline/powerline
 [vim-startify]:https://github.com/mhinz/vim-startify
+[vim-workspace]:https://github.com/bagrat/vim-workspace
 
 [wiki-screenshots]:https://github.com/ryanoasis/vim-devicons/wiki/Screenshots
 [wiki-faq]:https://github.com/ryanoasis/vim-devicons/wiki/FAQ


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

This adds a link to [`vim-workspace`](https://github.com/bagrat/vim-workspace) in the readme, as an integrated plugin, that works with `vim-devicons` out-of-the box.

#### How should this be manually tested?

N/A

#### Any background context you can provide?

N/A

#### What are the relevant tickets (if any)?

N/A

#### Screenshots (if appropriate or helpful)

![vim-workflow](https://raw.githubusercontent.com/bagrat/vim-workspace/60fadaeee65368f7d2d0a62b4dc452bf9ca99113/demo.jpg)
