### PR TITLE
Consistently point to recommended version of CtrlP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Add the following in your `.vimrc` or `.gvimrc`:
 
 ##### Set VimDevIcons to load _after_ these plugins!
 
-[NERDTree] | [vim-airline] | [CtrlP] | [powerline] | [Denite] | [unite] | [lightline.vim] | [vim-startify] | [vimfiler] | [flagship]
+[NERDTree] | [vim-airline] | [CtrlP][ctrlpvim-CtrlP] | [powerline] | [Denite] | [unite] | [lightline.vim] | [vim-startify] | [vimfiler] | [flagship]
 
 ##### Set encoding to UTF-8 to show glyphs
 
@@ -186,7 +186,7 @@ font, else things break!
 If you installed and setup things correctly you should now see icons in the [supported plugins](#features)!
 
 **Notes on include order:**
-* for support of these plugins: [NERDTree], [vim-airline], [CtrlP], [powerline], [Denite], [unite], [vimfiler], [flagship] you **must** configure vim to load those plugins **_before_** vim-devicons loads.
+* for support of these plugins: [NERDTree], [vim-airline], [CtrlP][ctrlpvim-CtrlP], [powerline], [Denite], [unite], [vimfiler], [flagship] you **must** configure vim to load those plugins **_before_** vim-devicons loads.
 * for better [nerdtree-git-plugin] support, you _should_ configure vim to load nerdtree-git-plugin **_before_** VimDevIcons loads.
 
 [Lightline Setup](#lightline-setup) and [Powerline Setup](#powerline-setup) require some extra setup as shown below:


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Fixes links

#### How should this be manually tested?
Review links

#### Any background context you can provide?
Was pointing at deprecated version

#### What are the relevant tickets (if any)?
N/A

#### Screenshots (if appropriate or helpful)
N/A