### PR TITLE
prevent error when g:airline_section_x is undefined

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -683,7 +683,8 @@ endfunction
 
 " scope: public
 function! AirlineWebDevIcons(...)
-  let w:airline_section_x = get(w:, 'airline_section_x', g:airline_section_x)
+  let w:airline_section_x = get(w:, 'airline_section_x',
+        \ get(g:, 'airline_section_x', ''))
   let w:airline_section_x .= ' %{WebDevIconsGetFileTypeSymbol()} '
   let hasFileFormatEncodingPart = airline#parts#ffenc() != ''
   if g:webdevicons_enable_airline_statusline_fileformat_symbols && hasFileFormatEncodingPart


### PR DESCRIPTION
I don't know why this happens, but I just got a bug report vim-airline/vim-airline#1627 where an error is caused by trying to access `g:airline_section_x` which seems to be undefined for that user.

So here is a fix, that does not unconditionally access that variable, but only when it exists.

fixes vim-airline/vim-airline#1627

Thanks!

