### PR TITLE
add support for symlink dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+__pycache__/

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -143,6 +143,10 @@ if !exists('g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol')
   endif
 endif
 
+if !exists('g:WebDevIconsUnicodeDecorateFolderNodesSymlinkSymbol')
+  let g:WebDevIconsUnicodeDecorateFolderNodesSymlinkSymbol =  ''
+endif
+
 if !exists('g:DevIconsDefaultFolderOpenSymbol')
     let g:DevIconsDefaultFolderOpenSymbol = ''
 endif
@@ -730,11 +734,16 @@ function! NERDTreeWebDevIconsRefreshListener(event)
   endif
 
   if !path.isDirectory
+    " Hey we got a regular file, lets get it's proper icon
     let flag = prePadding . WebDevIconsGetFileTypeSymbol(path.str()) . padding
+
   elseif path.isDirectory && g:WebDevIconsUnicodeDecorateFolderNodes == 1
+    " Ok we got a directory, some more tests and checks
     let directoryOpened = 0
 
     if g:DevIconsEnableFoldersOpenClose && len(path.flagSet._flagsForScope('webdevicons')) > 0
+      " did the user set different icons for open and close?
+
       " isOpen is not available on the path listener directly
       " but we added one via overriding particular keymappings for NERDTree
       if has_key(path, 'isOpen') && path.isOpen == 1
@@ -743,18 +752,40 @@ function! NERDTreeWebDevIconsRefreshListener(event)
     endif
 
     if g:WebDevIconsUnicodeDecorateFolderNodesExactMatches == 1
+      " Did the user enable exact matching of folder type/names
+      " think node_modules
       if g:DevIconsEnableFoldersOpenClose && directoryOpened
+        " the folder is open
         let flag = prePadding . g:DevIconsDefaultFolderOpenSymbol . padding
       else
-        let flag = prePadding . WebDevIconsGetFileTypeSymbol(path.str(), path.isDirectory, 0) . padding
+        " the folder is not open
+        if path.isSymLink
+          " We have a symlink
+          let flag = prePadding . g:WebDevIconsUnicodeDecorateFolderNodesSymlinkSymbol . padding
+        else
+          " We have a regular folder
+          let flag = prePadding . WebDevIconsGetFileTypeSymbol(path.str(), path.isDirectory, 0) . padding
+        endif
       endif
+
     else
+      " the user did not enable exact matching
       if g:DevIconsEnableFoldersOpenClose && directoryOpened
+        " the folder is open
         let flag = prePadding . g:DevIconsDefaultFolderOpenSymbol . padding
       else
-        let flag = prePadding . g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol . padding
+        " the folder is not open
+        if path.isSymLink
+          " We have a symlink
+          let flag = prePadding . g:WebDevIconsUnicodeDecorateFolderNodesSymlinkSymbol . padding
+        else
+          " We have a regular folder
+          let flag = prePadding . g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol . padding
+        endif
       endif
+
     endif
+
   else
     let flag = ''
   endif


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
This adds support to decorate directories that are symlinks with a different folder icon in nerdtree.

#### How should this be manually tested?
Start vim in a directory that has a symlink'd folder or create a test dir and symlink it somewhere.

#### Any background context you can provide?
While nerdtree already provides a way to see if a directory, it can be hard to read, especially if the path is pretty long. This small change is just a visual improvement.

#### What are the relevant tickets (if any)?
None! 
#### Screenshots (if appropriate or helpful)
<img width="693" alt="screen shot 2018-01-06 at 11 51 40 am" src="https://user-images.githubusercontent.com/2835826/34641832-063380f0-f2d8-11e7-93c8-4bb01e02e85b.png">
