### PR TITLE
Added support for Docker

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -315,6 +315,8 @@ function! s:setDictionaries()
         \ 'node_modules'                     : '',
         \ 'react.jsx'                        : '',
         \ 'procfile'                         : '',
+        \ 'dockerfile'                       : '',
+        \ 'docker-compose.yml'               : '',
         \}
 
   let s:file_node_pattern_matches = {


### PR DESCRIPTION
`Dockerfile` and `docker-compose.yml` are recognized as Docker related
files.

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)