### PR TITLE
Solving E15: Invalid expression

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -435,7 +435,7 @@ function! s:CursorHoldUpdate()
   call b:NERDTree.root.refreshFlags()
   call NERDTreeRender()
 
-  exec l.altwinnr . 'wincmd w'
+  exec l:altwinnr . 'wincmd w'
   exec l:winnr . 'wincmd w'
 endfunction
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Correction to a little error: `E15: Invalid expression: l.altwinnr . 'wincmd w'`

#### How should this be manually tested?

Solve this error:

```
Error detected while processing function <SNR>116_CursorHoldUpdate:
line   23:
E121: Undefined variable: l
Error detected while processing function <SNR>116_CursorHoldUpdate:
line   23:
E15: Invalid expression: l.altwinnr . 'wincmd w'
Executing CursorMoved Auto commands for "*"
```

#### Any background context you can provide?

Holding the cursor shows an error on the log.

#### What are the relevant tickets (if any)?

Bug

#### Screenshots (if appropriate or helpful)

none