### PR TITLE
Add leftrelease override to call the activatenode method on single click

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -327,6 +327,13 @@ if g:webdevicons_enable == 1 && g:webdevicons_enable_nerdtree == 1
       \ 'callback': 'WebDevIconsNERDTreeMapActivateNode',
       \ 'override': 1,
       \ 'scope': 'DirNode' })
+    
+    " <LeftRelease>
+    call NERDTreeAddKeyMap({
+      \ 'key': '<LeftRelease>',
+      \ 'callback': 'WebDevIconsNERDTreeMapActivateNode',
+      \ 'override': 1,
+      \ 'scope': 'DirNode' })
 
     " NERDTreeMapUpdirKeepOpen
     call NERDTreeAddKeyMap({


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
When you open a directory on the nerdtree plugin the directory icon doesn't open. This PR permits to call the activatenode method on the single click, when the user try to open a directory.

#### How should this be manually tested?
Try to open a directory on nerdtree plugin. The icon will change with on the single click event.

#### Any background context you can provide?
I don't think you need other info.

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/244997/46260247-cbc36280-c4e3-11e8-8bcd-58b20a501462.png)
