### PR TITLE
add Swift icons

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -307,7 +307,9 @@ function! s:setDictionaries()
         \ 'tsx'      : '',
         \ 'jl'       : '',
         \ 'pp'       : '',
-        \ 'vue'      : '﵂'
+        \ 'vue'      : '﵂',
+        \ 'swift'    : '',
+        \ 'xcplayground' : ''
         \}
 
   let s:file_node_exact_matches = {


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
The pull requests add support for .swift and .xcplayground files.

#### How should this be manually tested?
Can be tested by opening a .swift/.xcplayground file in (N)vi(M) with the plugin loaded.

#### Any background context you can provide?
Was a bit annoyed to find that Swift support was missing, especially as the primary occupation of Xcode is to act as a crash simulator.

#### What are the relevant tickets (if any)?
nil

#### Screenshots (if appropriate or helpful)
nil