### PR TITLE
#246: fix override when the g:NERDTreeMouseMode = 1

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -207,6 +207,28 @@ function! WebDevIconsNERDTreeMapActivateNode(node)
   endif
 endfunction
 
+" NERDTreeMapActivateNodeSingleMode 
+" handle the user activating a tree node if NERDTreeMouseMode is setted to 3
+" scope: global
+function! WebDevIconsNERDTreeMapActivateNodeSingleMode(node)
+  if g:NERDTreeMouseMode == 3
+    let isOpen = a:node.isOpen
+    if isOpen
+      let glyph = g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol
+    else
+      let glyph = g:DevIconsDefaultFolderOpenSymbol
+    endif
+    let a:node.path.isOpen = !isOpen
+    call WebDevIconsNERDTreeDirUpdateFlags(a:node, glyph)
+    " continue with normal activate logic
+    call a:node.activate()
+    " glyph change possible artifact clean-up
+    if g:DevIconsEnableNERDTreeRedraw ==# 1
+      redraw!
+    endif
+  endif
+endfunction
+
 function! WebDevIconsNERDTreeMapOpenRecursively(node)
   " normal original logic:
   call nerdtree#echo("Recursively opening node. Please wait...")
@@ -319,11 +341,11 @@ if g:webdevicons_enable == 1 && g:webdevicons_enable_nerdtree == 1
       \ 'callback': 'WebDevIconsNERDTreeMapActivateNode',
       \ 'override': 1,
       \ 'scope': 'DirNode' })
-    
+
     " <LeftRelease>
     call NERDTreeAddKeyMap({
       \ 'key': '<LeftRelease>',
-      \ 'callback': 'WebDevIconsNERDTreeMapActivateNode',
+      \ 'callback': 'WebDevIconsNERDTreeMapActivateNodeSingleMode',
       \ 'override': 1,
       \ 'scope': 'DirNode' })
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
This is a fix for the problem mentioned on https://github.com/ryanoasis/vim-devicons/pull/246#issuecomment-470973316
When the user has the g:NERDTreeMouseMode setted to  1, my previous pr override the 2clicks rule, so I added a new function to activate the node only if the g:NERDTreeMouseMode is setted to 3 (single click open any node).

#### How should this be manually tested?
Set g:NERDTreeMouseMode to 1 or 2 and the directory nodes are opened with double click, instead if you set g:NERDTreeMouseMode to 3 the directory nodes are opened with the single click and the icons work correctly.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
