### PR TITLE
Replace vim-workspace with vim-buffet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 </div>
 
-> Supports plugins such as [NERDTree](https://github.com/scrooloose/nerdtree), [vim-airline](https://github.com/vim-airline/vim-airline), [CtrlP](https://github.com/ctrlpvim/ctrlp.vim), [powerline](https://github.com/powerline/powerline), [denite](https://github.com/Shougo/denite.nvim), [unite](https://github.com/Shougo/unite.vim), [lightline.vim](https://github.com/itchyny/lightline.vim), [vim-startify](https://github.com/mhinz/vim-startify), [vimfiler](https://github.com/Shougo/vimfiler.vim), [vim-workspace](https://github.com/bagrat/vim-workspace) and [flagship](https://github.com/tpope/vim-flagship).
+> Supports plugins such as [NERDTree](https://github.com/scrooloose/nerdtree), [vim-airline](https://github.com/vim-airline/vim-airline), [CtrlP](https://github.com/ctrlpvim/ctrlp.vim), [powerline](https://github.com/powerline/powerline), [denite](https://github.com/Shougo/denite.nvim), [unite](https://github.com/Shougo/unite.vim), [lightline.vim](https://github.com/itchyny/lightline.vim), [vim-startify](https://github.com/mhinz/vim-startify), [vimfiler](https://github.com/Shougo/vimfiler.vim), [vim-buffet](https://github.com/bagrat/vim-buffet) and [flagship](https://github.com/tpope/vim-flagship).
 
 <h3 align="center">
   <img src="https://github.com/ryanoasis/vim-devicons/wiki/screenshots/v0.10.x/overall-screenshot.png" alt="vim-devicons overall screenshot" />


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Updates the name of the renamed `vim-buffet` (fka `vim-workspace`) plugin name in the README.

#### How should this be manually tested?

NA

#### Any background context you can provide?

NA

#### What are the relevant tickets (if any)?

https://github.com/bagrat/vim-buffet/issues/14

#### Screenshots (if appropriate or helpful)

NA
