### PR TITLE
Add support for mdx files

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -137,6 +137,7 @@ function! s:setDictionaries()
         \ 'css'      : '',
         \ 'less'     : '',
         \ 'md'       : '',
+        \ 'mdx'      : '',
         \ 'markdown' : '',
         \ 'rmd'      : '',
         \ 'json'     : '',


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Adds support for 'mdx' markdown variant

#### How should this be manually tested?
Create a file with a `.mdx` extension and check the icon

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/7675500/58385454-1b194e80-7ff1-11e9-8fbe-cd1e595eb4e2.png)

