### PR TITLE
Adopt denite ver 3

### DIFF
--- a/autoload/devicons/plugins/denite.vim
+++ b/autoload/devicons/plugins/denite.vim
@@ -1,6 +1,6 @@
 function! devicons#plugins#denite#init() abort
   let s:denite_ver = (exists('*denite#get_status_mode') ? 2 : 3)
-  if s:s:denite_ver == 3
+  if s:denite_ver == 3
     call denite#custom#source('file/rec,file_mru,file/old,buffer,directory/rec,directory_mru', 'converters', ['devicons_denite_converter'])
   else
     call denite#custom#source('file_rec,file_mru,file_old,buffer,directory_rec,directory_mru', 'converters', ['devicons_denite_converter'])

--- a/autoload/devicons/plugins/denite.vim
+++ b/autoload/devicons/plugins/denite.vim
@@ -1,5 +1,10 @@
 function! devicons#plugins#denite#init() abort
-  call denite#custom#source('file_rec,file_mru,file_old,buffer,directory_rec,directory_mru', 'converters', ['devicons_denite_converter'])
+  let s:denite_ver = (exists('*denite#get_status_mode') ? 2 : 3)
+  if s:s:denite_ver == 3
+    call denite#custom#source('file/rec,file_mru,file/old,buffer,directory/rec,directory_mru', 'converters', ['devicons_denite_converter'])
+  else
+    call denite#custom#source('file_rec,file_mru,file_old,buffer,directory_rec,directory_mru', 'converters', ['devicons_denite_converter'])
+  endif
 endfunction
 
 " vim: tabstop=2 softtabstop=2 shiftwidth=2 expandtab:


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Denite.nvim was updated ver 3.0 and denite's api was changed but vim-devicons's denite api is old. Therefore, I fixed these api. And these patch also support old denite version.

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#265

#### Screenshots (if appropriate or helpful)
<img width="440" alt="スクリーンショット 2019-06-27 14 10 09" src="https://user-images.githubusercontent.com/36619465/60236169-61f6ae80-98e5-11e9-99ea-983d310b9aea.png">