### PR TITLE
show filetype icons in denite file source

### DIFF
--- a/autoload/devicons/plugins/denite.vim
+++ b/autoload/devicons/plugins/denite.vim
@@ -1,9 +1,9 @@
 function! devicons#plugins#denite#init() abort
   let s:denite_ver = (exists('*denite#get_status_mode') ? 2 : 3)
   if s:denite_ver == 3
-    call denite#custom#source('file/rec,file_mru,file/old,buffer,directory/rec,directory_mru', 'converters', ['devicons_denite_converter'])
+    call denite#custom#source('file,file/rec,file_mru,file/old,buffer,directory/rec,directory_mru', 'converters', ['devicons_denite_converter'])
   else
-    call denite#custom#source('file_rec,file_mru,file_old,buffer,directory_rec,directory_mru', 'converters', ['devicons_denite_converter'])
+    call denite#custom#source('file,file_rec,file_mru,file_old,buffer,directory_rec,directory_mru', 'converters', ['devicons_denite_converter'])
   endif
 endfunction
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

Is there any reason while `file` is not among the sources for `denite`? Feel free to close if so, otherwise this PR fixes it.