### PR TITLE
Fix for issue #276 (the symbol for opened folder in NERDTree is not working)

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -314,6 +314,13 @@ if g:webdevicons_enable == 1 && g:webdevicons_enable_nerdtree == 1
       \ 'override': 1,
       \ 'scope': 'DirNode' })
 
+    " NERDTreeMapCustomOpen
+    call NERDTreeAddKeyMap({
+      \ 'key': g:NERDTreeMapCustomOpen,
+      \ 'callback': 'WebDevIconsNERDTreeMapActivateNode',
+      \ 'override': 1,
+      \ 'scope': 'DirNode' })
+
     " NERDTreeMapOpenRecursively
     call NERDTreeAddKeyMap({
       \ 'key': g:NERDTreeMapOpenRecursively,


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Fixes issue #276. Pressing \<CR\> on NERDTree to open/close a folder now toggles the folder icon.
#### How should this be manually tested?
Press \<CR\> on a folder in NERDTree.
#### Any background context you can provide?
On July 1st, NERDTree merged pull request [#1011](https://github.com/scrooloose/nerdtree/pull/1011) where new \<CR\> functionality was added.

There's now a `NERDTreeMapCustomOpen` mapping that handles `NERDTree-<CR>`, in addition to the already existing `NERDTreeMapActivateNode` that handled `NERDTree-o`, and it broke the toggling of the open/close folder icons.

According to the NERDTree help on `NERDTreeMapCustomOpen`:

> The default value matches what NERDTree-o does.

So, adding a key map to `NERDTreeMapCustomOpen` with the same callback parameter of `NERDTreeMapActivateNode` restores previous behavior, in which both `NERDTree-o` and `NERDTree-<CR>` toggle open/close folder icons.

#### What are the relevant tickets (if any)?
#276
#### Screenshots (if appropriate or helpful)
