### PR TITLE
add mjs icon

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -142,6 +142,7 @@ function! s:setDictionaries()
         \ 'rmd'      : '',
         \ 'json'     : '',
         \ 'js'       : '',
+        \ 'mjs'      : '',
         \ 'jsx'      : '',
         \ 'rb'       : '',
         \ 'php'      : '',


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Resolve issue #282 

If you open .mjs file, JavaScript icon will be displayed

#### How should this be manually tested?
You open `.mjs` file.

#### Any background context you can provide?

Issue number #282

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

![Screenshot from 2019-09-14 02-07-16](https://user-images.githubusercontent.com/36619465/64881008-9b44ec00-d694-11e9-8e3e-8bbc72a5f5d4.png)

![Screenshot from 2019-09-14 02-07-05](https://user-images.githubusercontent.com/36619465/64881019-a0a23680-d694-11e9-877d-ecfadd265034.png)

