### PR TITLE
add toml file's icon

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -157,6 +157,7 @@ function! s:setDictionaries()
         \ 'ini'      : '',
         \ 'yml'      : '',
         \ 'yaml'     : '',
+        \ 'toml'     : '',
         \ 'bat'      : '',
         \ 'jpg'      : '',
         \ 'jpeg'     : '',


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Resolve issue #284

If you open `.toml` file, gear icon will be displayed

#### How should this be manually tested?

You open `.toml` file.

#### Any background context you can provide?

Issue number #284

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

<img width="109" alt="スクリーンショット 2019-09-17 8 24 14" src="https://user-images.githubusercontent.com/36619465/64999935-96966700-d924-11e9-9583-c4ad62392784.png">

<img width="225" alt="スクリーンショット 2019-09-17 8 24 22" src="https://user-images.githubusercontent.com/36619465/64999939-9b5b1b00-d924-11e9-8f91-a091af8ed43a.png">


