### PR TITLE
add elm icon

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -231,6 +231,7 @@ function! s:setDictionaries()
         \ 'jl'       : '',
         \ 'pp'       : '',
         \ 'vue'      : '﵂',
+        \ 'elm'      : '',
         \ 'swift'    : '',
         \ 'xcplayground' : ''
         \}


### PR DESCRIPTION
I write this patch to resolve issue number #288 
Please check this Pull Request.

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Resolve issue #288 

#### How should this be manually tested?
Open `.elm` flie

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

- vim-airline

<img width="287" alt="スクリーンショット 2019-10-25 19 01 29" src="https://user-images.githubusercontent.com/36619465/67562567-e9e8aa00-f759-11e9-9750-887f5f065472.png">

- nerdtree

<img width="130" alt="スクリーンショット 2019-10-25 19 01 13" src="https://user-images.githubusercontent.com/36619465/67562559-e6edb980-f759-11e9-9e3d-eb611cc6330e.png">

