### PR TITLE
Added configurable padding in vim-airline tabline

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/webdevicons.vim
+++ b/autoload/airline/extensions/tabline/formatters/webdevicons.vim
@@ -5,10 +5,9 @@
 
 function! airline#extensions#tabline#formatters#webdevicons#format(bufnr, buffers) abort
   " Call original formatter.
-  let prePadding = g:WebDevIconsTabAirLineBeforeGlyphPadding
-  let postPadding = g:WebDevIconsTabAirLineAfterGlyphPadding
   let originalFormatter = airline#extensions#tabline#formatters#{g:_webdevicons_airline_orig_formatter}#format(a:bufnr, a:buffers)
-  return originalFormatter . prePadding . WebDevIconsGetFileTypeSymbol(bufname(a:bufnr)) . postPadding
+  return originalFormatter . g:WebDevIconsTabAirLineBeforeGlyphPadding .
+         \ WebDevIconsGetFileTypeSymbol(bufname(a:bufnr)) . g:WebDevIconsTabAirLineAfterGlyphPadding
 endfunction
 
 " modeline syntax:

--- a/autoload/airline/extensions/tabline/formatters/webdevicons.vim
+++ b/autoload/airline/extensions/tabline/formatters/webdevicons.vim
@@ -5,8 +5,10 @@
 
 function! airline#extensions#tabline#formatters#webdevicons#format(bufnr, buffers) abort
   " Call original formatter.
+  let prePadding = g:WebDevIconsTabAirLineBeforeGlyphPadding
+  let postPadding = g:WebDevIconsTabAirLineAfterGlyphPadding
   let originalFormatter = airline#extensions#tabline#formatters#{g:_webdevicons_airline_orig_formatter}#format(a:bufnr, a:buffers)
-  return originalFormatter . ' ' . WebDevIconsGetFileTypeSymbol(bufname(a:bufnr))
+  return originalFormatter . prePadding . WebDevIconsGetFileTypeSymbol(bufname(a:bufnr)) . postPadding
 endfunction
 
 " modeline syntax:

--- a/doc/webdevicons.txt
+++ b/doc/webdevicons.txt
@@ -623,6 +623,18 @@ Extra Configuration ~
 >
   " Adding the custom source to denite
   let g:webdevicons_enable_denite = 1
+
+
+
+  " the amount of space to use after the glyph character in vim-airline
+	tabline(default '')
+  let g:WebDevIconsTabAirLineAfterGlyphPadding = ' '
+
+
+
+  " the amount of space to use before the glyph character in vim-airline
+	tabline(default ' ')
+  let g:WebDevIconsTabAirLineBeforeGlyphPadding = ' '
 <
 -------------------------------------------------------------------------------
                                                   *devicons-character-mappings*

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -72,6 +72,8 @@ call s:set('g:WebDevIconsNerdTreeBeforeGlyphPadding', ' ')
 call s:set('g:WebDevIconsNerdTreeAfterGlyphPadding', ' ')
 call s:set('g:WebDevIconsNerdTreeGitPluginForceVAlign', 1)
 call s:set('g:NERDTreeUpdateOnCursorHold', 1)
+call s:set('g:WebDevIconsTabAirLineBeforeGlyphPadding', ' ')
+call s:set('g:WebDevIconsTabAirLineAfterGlyphPadding', '')
 
 " config defaults {{{1
 "========================================================================


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Added two new variables to configure how the vim-airline tabline shows the icons.

#### How should this be manually tested?
Just Installed, it should work as before. Changing the new variables should change how the name in the vim-airline tabline is shown. 

#### Any background context you can provide?
After changing to Kitty, I found a small problem with the icons.

#### Screenshots
From:
<img width="480" alt="Captura de pantalla 2019-12-23 a las 18 40 23" src="https://user-images.githubusercontent.com/9999104/71372130-c0aa9580-25b3-11ea-9403-d1e4a065126b.png">


After changing: 

```
  let g:WebDevIconsTabAirLineAfterGlyphPadding = ' '
  let g:WebDevIconsTabAirLineBeforeGlyphPadding = ''
```

To:
<img width="568" alt="Captura de pantalla 2019-12-23 a las 18 39 51" src="https://user-images.githubusercontent.com/9999104/71372136-c7d1a380-25b3-11ea-931b-f6dbb8d4301a.png">
