### PR TITLE
Fixed vim re-source vimrc bug when NERDTree is lazy load

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -380,7 +380,7 @@ endfunction
 
 " scope: local
 function! s:softRefreshNerdTree()
-  if g:webdevicons_enable_nerdtree == 1 && g:NERDTree.IsOpen()
+  if g:webdevicons_enable_nerdtree == 1 && exists('g:NERDTree') && g:NERDTree.IsOpen()
     NERDTreeToggle
     NERDTreeToggle
   endif


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Fixed an error out put when re-sourcing vimrc and NERDTree plugin is lazy load

#### How should this be manually tested?
:source $MYVIMRC

#### Any background context you can provide?
Only happened if you use NERDTree as lazy load and not open NERDTree just yet, then re-soucing vimrc.

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/4990592/74823692-1300fc00-5342-11ea-8b40-ad42f2ba0f7c.png)
