### PR TITLE
To distinguish the system logo

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -523,7 +523,7 @@ function! WebDevIconsGetFileFormatSymbol(...)
       elseif s:lsb =~# 'Debian'
         let fileformat = ''
       elseif s:lsb =~# 'Dock'
-        let s:lsb = ''
+        let fileformat = ''
       else
         let fileformat = ''
       endif

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -513,7 +513,20 @@ function! WebDevIconsGetFileFormatSymbol(...)
     if s:isDarwin()
       let fileformat = ''
     else
-      let fileformat = ''
+      let s:lsb = system('lsb_release -i')
+      if s:lsb =~# 'Arch'
+        let fileformat = ''
+      elseif s:lsb =~# 'Ubuntu'
+        let fileformat = ''
+      elseif s:lsb =~# 'Cent'
+        let fileformat = ''
+      elseif s:lsb =~# 'Debian'
+        let fileformat = ''
+      elseif s:lsb =~# 'Dock'
+        let s:lsb = ''
+      else
+        let fileformat = ''
+      endif
     endif
   elseif &fileformat ==? 'mac'
     let fileformat = ''


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [ ] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

why not distinguish between different system icons when use unix operation system. Such as Arch, Ubuntu or Cent.

the command `lsb_release -i` will show what operation system you use.

```bash
$  lsb_release -i
Distributor ID:	Ubuntu
```

So, I just try to add some different icon when I use different linux. Now, I am using Arch.

![image](https://user-images.githubusercontent.com/41265413/75777208-80744a00-5d90-11ea-974f-d1de42233670.png)

Now, I can see the Arch logo.

And the icons can find in this. <https://raw.githubusercontent.com/just3ws/nerd-font-cheatsheets/master/font-linux.md>

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
