### PR TITLE
Update make and cmake file icon

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -297,6 +297,8 @@ function! s:setDictionaries()
         \ 'procfile'                         : '',
         \ 'dockerfile'                       : '',
         \ 'docker-compose.yml'               : '',
+        \ 'makefile'                         : '',
+        \ 'cmakelists.txt'                   : ''
         \}
 
   let s:file_node_pattern_matches = {


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

I found that `Makefile` and `CMakeLists.txt` files were not sensible. So IMHO it's better to make their file icons to `` until [NerdFonts](https://github.com/ryanoasis/nerd-fonts) support these two filetypes.

#### How should this be manually tested?

Open `Makefile` and `CMakeLists.txt` files in vim.

#### Any background context you can provide?

Nothing

#### What are the relevant tickets (if any)?

Nothing

#### Screenshots (if appropriate or helpful)

Before:
![Screenshot_20200311_194717](https://user-images.githubusercontent.com/20282795/76413844-251a0b80-63d1-11ea-86d7-7e2fc60db000.png)
