### PR TITLE
Fix error with O and X in NERDTree (Issue #268)

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -232,8 +232,8 @@ endfunction
 function! WebDevIconsNERDTreeMapOpenRecursively(node)
   " normal original logic:
   call nerdtree#echo('Recursively opening node. Please wait...')
-  call a:node.openRecursively()
   call WebDevIconsNERDTreeDirOpenRecursively(a:node)
+  call a:node.openRecursively()
   " continue with normal original logic:
   call b:NERDTree.render()
   " glyph change possible artifact clean-up


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
This PR fixes the error with O and X in NERDTree not working correctly.

#### How should this be manually tested?
Use O and X in NERDTree before and after the patch.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
#268 and #243 
#### Screenshots (if appropriate or helpful)
