### PR TITLE
Add more files from the Ruby ecosystem

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -163,6 +163,7 @@ function! s:setDictionaries()
         \ 'htm'      : '',
         \ 'html'     : '',
         \ 'slim'     : '',
+        \ 'haml'     : '',
         \ 'ejs'      : '',
         \ 'css'      : '',
         \ 'less'     : '',
@@ -175,6 +176,8 @@ function! s:setDictionaries()
         \ 'mjs'      : '',
         \ 'jsx'      : '',
         \ 'rb'       : '',
+        \ 'gemspec'  : '',
+        \ 'rake'     : '',
         \ 'php'      : '',
         \ 'py'       : '',
         \ 'pyc'      : '',
@@ -297,6 +300,8 @@ function! s:setDictionaries()
         \ 'procfile'                         : '',
         \ 'dockerfile'                       : '',
         \ 'docker-compose.yml'               : '',
+        \ 'rakefile'                         : '',
+        \ 'config.ru'                        : '',
         \ 'makefile'                         : '',
         \ 'cmakelists.txt'                   : ''
         \}
@@ -310,6 +315,7 @@ function! s:setDictionaries()
         \ '.*materialize.*\.css$' : '',
         \ '.*mootools.*\.js$'     : '',
         \ '.*vimrc.*'             : '',
+        \ 'Gemfile$'              : '',
         \ 'Vagrantfile$'          : ''
         \}
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

This adds some more mappings to nicely display files from the ruby-world

- haml is a preprocessor for erb, commonly used in rails
- gemspec is the package-definition for rubygems
- rake contains code for rake-tasks, see Rakefile
- Rakefile is the equivalent of a Makefile for rake (a ruby make)
- config.ru is used by web-/app-servers as entrypoint
- Gemfile contains dependencies

#### How should this be manually tested?

The source-code of any rails-app should cover most of the files above.

If you have nothing at hand, try a checkout of https://github.com/hitobito/hitobito_generic, which contains those files in the project-root, in `lib/tasks/*.rake` and `app/views/people/*.haml`. https://github.com/hitobito/hitobito also contains a `config.ru` in the project-root.

#### Any background context you can provide?

Ruby is a language of careful balance. Its creator, Yukihiro “Matz” Matsumoto, blended parts of his favorite languages (Perl, Smalltalk, Eiffel, Ada, and Lisp) to form a new language that balanced functional programming with imperative programming.

He has often said that he is “trying to make Ruby natural, not simple,” in a way that mirrors life.

Building on this, he adds:

    Ruby is simple in appearance, but is very complex inside, just like our human body.

#### What are the relevant tickets (if any)?

none

#### Screenshots (if appropriate or helpful)

![2020-05-05-075925_313x1066_scrot](https://user-images.githubusercontent.com/72198/81038517-9ee8e580-8ea6-11ea-8c4a-f4846f84da9c.png)

![2020-05-05-080020_367x290_scrot](https://user-images.githubusercontent.com/72198/81038522-a1e3d600-8ea6-11ea-9269-bcd724809fdb.png)
