### PR TITLE
[RFC] add syntax groups to webdevicons_conceal_nerdtree_brackets augroup

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -364,8 +364,8 @@ function! s:setSyntax()
   if g:webdevicons_enable_nerdtree == 1 && g:webdevicons_conceal_nerdtree_brackets == 1
     augroup webdevicons_conceal_nerdtree_brackets
       au!
-      autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\]" contained conceal containedin=NERDTreeFlags
-      autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\[" contained conceal containedin=NERDTreeFlags
+      autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\]" contained conceal containedin=NERDTreeFlags,NERDTreeFile,NERDTreeExecFile
+      autocmd FileType nerdtree syntax match hideBracketsInNerdTree "\[" contained conceal containedin=NERDTreeFlags,NERDTreeFile,NERDTreeExecFile
       autocmd FileType nerdtree setlocal conceallevel=3
       autocmd FileType nerdtree setlocal concealcursor=nvic
     augroup END


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [ x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [ x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x ] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Adds additional syntax groups `NERDTreeFile` and `NERDTreeExecFile` to `webdevicons_conceal_nerdtree_brackets` augroup

#### How should this be manually tested?

#### Any background context you can provide?

#### What are the relevant tickets (if any)?
https://github.com/ryanoasis/vim-devicons/issues/330
https://github.com/ryanoasis/vim-devicons/issues/278

https://github.com/tiagofumo/vim-nerdtree-syntax-highlight/issues/31

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/10278096/82621609-73e1df80-9b90-11ea-8f0c-6000c7cf398d.png)


This change https://github.com/ryanoasis/vim-devicons/commit/0b6a7bd9f5944c6270bd2a2037428e1d83aa9608 modified the `containedin` from `ALL` to the more strict `NERDTreeFlags`. tiagofumo/vim-nerdtree-syntax-highlight (linked above) depends on these additional groups in order to work. 

I'm wondering if issue #330 is actually someone who is using `tiagofumo/vim-nerdtree-syntax-highlight` ? Thoughts? 