### PR TITLE
Add option to disable showing distro for encoding

### DIFF
--- a/doc/webdevicons.txt
+++ b/doc/webdevicons.txt
@@ -674,6 +674,11 @@ Character Mappings ~
 <
 
 >
+  " disable showing the distribution for unix file encoding (enabled by default with 1)
+  let g:DevIconsEnableDistro = 0
+<
+
+>
   " enable custom folder/directory glyph exact matching
   " (enabled by default when g:WebDevIconsUnicodeDecorateFolderNodes is set to 1)
   let WebDevIconsUnicodeDecorateFolderNodesExactMatches = 1

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -66,6 +66,7 @@ call s:set('g:WebDevIconsUnicodeDecorateFolderNodes', 1)
 call s:set('g:DevIconsEnableFoldersOpenClose', 0)
 call s:set('g:DevIconsEnableFolderPatternMatching', 1)
 call s:set('g:DevIconsEnableFolderExtensionPatternMatching', 0)
+call s:set('g:DevIconsEnableDistro', 1)
 call s:set('g:WebDevIconsUnicodeDecorateFolderNodesExactMatches', 1)
 call s:set('g:WebDevIconsUnicodeGlyphDoubleWidth', 1)
 call s:set('g:WebDevIconsNerdTreeBeforeGlyphPadding', ' ')
@@ -96,7 +97,7 @@ function s:getDistro()
     return s:distro
   endif
 
-  if executable('lsb_release')
+  if g:DevIconsEnableDistro && executable('lsb_release')
     let s:lsb = system('lsb_release -i')
     if s:lsb =~# 'Arch'
       let s:distro = ''


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

It adds the `g:DevIconsEnableDistro` configuration option to control if the distribution icons should be shown when the file encoding is Unix.

#### How should this be manually tested?

Check if on a supported Linux distribution the distribution specific icon is shown in the default configuration and the generic icon (Tux) is used when `g:DevIconsEnableDistro` is set to `0`.

#### Any background context you can provide?

On my system `lsb_release -i` is really slow:

    $ time lsb_release -i
    Distributor ID:	Debian
    lsb_release -i  0.93s user 0.07s system 100% cpu 1.003 total

Since I use this plugin together with [vim-airline](https://github.com/vim-airline/vim-airline), `lsb_release -i` is called on each startup to get the current distribution. This slows the startup down significantly.