### PR TITLE
NERDTree-Git variable has been renamed.

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -71,7 +71,8 @@ call s:set('g:WebDevIconsUnicodeGlyphDoubleWidth', 1)
 call s:set('g:WebDevIconsNerdTreeBeforeGlyphPadding', ' ')
 call s:set('g:WebDevIconsNerdTreeAfterGlyphPadding', ' ')
 call s:set('g:WebDevIconsNerdTreeGitPluginForceVAlign', 1)
-call s:set('g:NERDTreeUpdateOnCursorHold', 1)
+call s:set('g:NERDTreeUpdateOnCursorHold', 1) " Obsolete: For backward compatibility
+call s:set('g:NERDTreeGitStatusUpdateOnCursorHold', 1)
 call s:set('g:WebDevIconsTabAirLineBeforeGlyphPadding', ' ')
 call s:set('g:WebDevIconsTabAirLineAfterGlyphPadding', '')
 
@@ -388,7 +389,7 @@ endfunction
 " scope: local
 " stole solution/idea from nerdtree-git-plugin :)
 function! s:CursorHoldUpdate()
-  if g:NERDTreeUpdateOnCursorHold != 1
+  if g:NERDTreeUpdateOnCursorHold != 1 || g:NERDTreeGitStatusUpdateOnCursorHold != 1
     return
   endif
 

--- a/test/default_setting.vim
+++ b/test/default_setting.vim
@@ -32,7 +32,8 @@ function! s:suite.ConfigOptions()
   call s:assert.equals(g:WebDevIconsNerdTreeBeforeGlyphPadding, ' ')
   call s:assert.equals(g:WebDevIconsNerdTreeAfterGlyphPadding, ' ')
   call s:assert.equals(g:WebDevIconsNerdTreeGitPluginForceVAlign, 1)
-  call s:assert.equals(g:NERDTreeUpdateOnCursorHold, 1)
+  call s:assert.equals(g:NERDTreeUpdateOnCursorHold, 1) " Obsolete: for backward compatibility
+  call s:assert.equals(g:NERDTreeGitStatusUpdateOnCursorHold, 1)
   call s:assert.equals(g:WebDevIconsTabAirLineBeforeGlyphPadding, ' ')
   call s:assert.equals(g:WebDevIconsTabAirLineAfterGlyphPadding, '')
 endfunction


### PR DESCRIPTION
g:NERDTreeUpdateOnCursorHold has been renamed g:NERDTreeGitStatusUpdateOnCursorHold and gives a 'deprecated' warning on startup.

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

As of commit https://github.com/Xuyuanp/nerdtree-git-plugin/commit/31aaa3c1153dc8fc0f4f5aac4df5cc5243048bb5 some variables of nerdtree-git-plugin were renamed and marked as deprecated. With commit https://github.com/Xuyuanp/nerdtree-git-plugin/commit/c546443935d0d617d03347b0b8108295761559bc the default log level was changed to 'warning'. Now the use of deprecated variables triggers a warning message on startup.

This PR renames one variable (`g:NERDTreeUpdateOnCursorHold`) and stops the warning from being triggered.

