### PR TITLE
Updated the deprecated name g:NERDTreeUpdateOnCursorHold to g:NERDTre…

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -71,7 +71,7 @@ call s:set('g:WebDevIconsUnicodeGlyphDoubleWidth', 1)
 call s:set('g:WebDevIconsNerdTreeBeforeGlyphPadding', ' ')
 call s:set('g:WebDevIconsNerdTreeAfterGlyphPadding', ' ')
 call s:set('g:WebDevIconsNerdTreeGitPluginForceVAlign', 1)
-call s:set('g:NERDTreeUpdateOnCursorHold', 1)
+call s:set('g:NERDTreeGitStatusUpdateOnCursorHold', 1)
 call s:set('g:WebDevIconsTabAirLineBeforeGlyphPadding', ' ')
 call s:set('g:WebDevIconsTabAirLineAfterGlyphPadding', '')
 
@@ -388,7 +388,7 @@ endfunction
 " scope: local
 " stole solution/idea from nerdtree-git-plugin :)
 function! s:CursorHoldUpdate()
-  if g:NERDTreeUpdateOnCursorHold != 1
+  if g:NERDTreeGitStatusUpdateOnCursorHold != 1
     return
   endif
 

--- a/test/default_setting.vim
+++ b/test/default_setting.vim
@@ -32,7 +32,7 @@ function! s:suite.ConfigOptions()
   call s:assert.equals(g:WebDevIconsNerdTreeBeforeGlyphPadding, ' ')
   call s:assert.equals(g:WebDevIconsNerdTreeAfterGlyphPadding, ' ')
   call s:assert.equals(g:WebDevIconsNerdTreeGitPluginForceVAlign, 1)
-  call s:assert.equals(g:NERDTreeUpdateOnCursorHold, 1)
+  call s:assert.equals(g:NERDTreeGitStatusUpdateOnCursorHold, 1)
   call s:assert.equals(g:WebDevIconsTabAirLineBeforeGlyphPadding, ' ')
   call s:assert.equals(g:WebDevIconsTabAirLineAfterGlyphPadding, '')
 endfunction


### PR DESCRIPTION
…eGitStatusUpdateOnCursorHold

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Update the deprecated variable name. Currently there is an error on startup printed by the `nerdtree-git-plugin`:
```
[nerdtree-git-status] option 'g:NERDTreeUpdateOnCursorHold' is deprecated, please use 'g:NERDTreeGitStatusUpdateOnCursorHold'
```
This patch updates the variable name to the new one.

#### How should this be manually tested?

Start Vim, check if the above error is printed.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
