### PR TITLE
Add support for leaderf

### DIFF
--- a/autoload/devicons/plugins/leaderf.vim
+++ b/autoload/devicons/plugins/leaderf.vim
@@ -1,0 +1,6 @@
+function! devicons#plugins#leaderf#init() abort
+  let g:Lf_DevIconsExactSymbols = extend(g:WebDevIconsUnicodeDecorateFileNodesPatternSymbols, get(g:, 'Lf_DevIconsExactSymbols', {}))
+  let g:Lf_DevIconsExtensionSymbols = extend(g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols, get(g:, 'Lf_DevIconsExtensionSymbols', {}))
+endfunction
+
+" vim: tabstop=2 softtabstop=2 shiftwidth=2 expandtab:

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -54,6 +54,7 @@ call s:set('g:webdevicons_enable_airline_statusline_fileformat_symbols', 1)
 call s:set('g:webdevicons_enable_flagship_statusline', 1)
 call s:set('g:webdevicons_enable_flagship_statusline_fileformat_symbols', 1)
 call s:set('g:webdevicons_enable_startify', 1)
+call s:set('g:webdevicons_enable_leaderf', 1)
 call s:set('g:webdevicons_conceal_nerdtree_brackets', 1)
 call s:set('g:DevIconsAppendArtifactFix', has('gui_running') ? 1 : 0)
 call s:set('g:DevIconsArtifactFixChar', ' ')
@@ -446,6 +447,7 @@ function! s:initialize()
   if exists('g:loaded_vimfiler') && g:webdevicons_enable_vimfiler | call devicons#plugins#vimfiler#init() | endif
   if exists('g:loaded_ctrlp') && g:webdevicons_enable_ctrlp | call devicons#plugins#ctrlp#init() | endif
   if exists('g:loaded_startify') && g:webdevicons_enable_startify | call devicons#plugins#startify#init() | endif
+  if exists('g:leaderf_loaded') && g:webdevicons_enable_leaderf | call devicons#plugins#leaderf#init() | endif
 endfunction
 
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Add support for leaderf

#### How should this be manually tested?
![image](https://user-images.githubusercontent.com/32936898/93099850-15aab080-f6db-11ea-83ef-8fab52bad516.png)
the unicode char cannot display so i had to use screenshot.
![image](https://user-images.githubusercontent.com/32936898/93099964-37a43300-f6db-11ea-9c5f-5c6e53a1e4a0.png)

Now, leaderf can use g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols.
#### Any background context you can provide?
See <https://github.com/Yggdroot/LeaderF/blob/master/doc/leaderf.txt#L928-L942>
#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
