### PR TITLE
Add icon for .zshenv and .zprofile

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -298,6 +298,8 @@ function! s:setDictionaries()
         \ '.gitlab-ci.yml'                   : '',
         \ '.bashrc'                          : '',
         \ '.zshrc'                           : '',
+        \ '.zshenv'                          : '',
+        \ '.zprofile'                        : '',
         \ '.vimrc'                           : '',
         \ '.gvimrc'                          : '',
         \ '_vimrc'                           : '',


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

This PR adds the a symbol for `.zshenv` and `.zprofile`. It coincides with that of `.zshrc` (a cog) for consistency.

#### How should this be manually tested?

Simply open `.zshrc` or `.zprofile`

#### Any background context you can provide?

It's been bugging me for a while that `.zshrc` gets a symbol while other special files don't.
