### PR TITLE
[WIP] add vim9script in fileformatsymbol's method

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -552,26 +552,48 @@ function! s:DevIconsGetArtifactFix()
 endfunction
 
 " scope: public
-function! WebDevIconsGetFileFormatSymbol(...)
-  let fileformat = ''
-  let bomb = ''
+if exists(":def")
+  def WebDevIconsGetFileFormatSymbol(): string
+    var fileformat = ''
+    var bomb = ''
+    if (&bomb && g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol !=? '')
+      bomb = g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol .. ' '
+    endif
 
-  if (&bomb && g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol !=? '')
-    let bomb = g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol . ' '
-  endif
+    if &fileformat ==? 'dos'
+      fileformat = ''
+    elseif &fileformat ==? 'unix'
+      fileformat = s:isDarwin() ? '' : s:getDistro()
+    elseif &fileformat ==? 'mac'
+      fileformat = ''
+    endif
 
-  if &fileformat ==? 'dos'
-    let fileformat = ''
-  elseif &fileformat ==? 'unix'
-    let fileformat = s:isDarwin() ? '' : s:getDistro()
-  elseif &fileformat ==? 'mac'
-    let fileformat = ''
-  endif
+    var artifactFix = s:DevIconsGetArtifactFix()
 
-  let artifactFix = s:DevIconsGetArtifactFix()
+    return bomb .. fileformat .. artifactFix
+  enddef
+else
+  function! WebDevIconsGetFileFormatSymbol(...)
+    let fileformat = ''
+    let bomb = ''
 
-  return bomb . fileformat . artifactFix
-endfunction
+    if (&bomb && g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol !=? '')
+      let bomb = g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol . ' '
+    endif
+
+    if &fileformat ==? 'dos'
+      let fileformat = ''
+    elseif &fileformat ==? 'unix'
+      let fileformat = s:isDarwin() ? '' : s:getDistro()
+    elseif &fileformat ==? 'mac'
+      let fileformat = ''
+    endif
+
+    let artifactFix = s:DevIconsGetArtifactFix()
+
+    return bomb . fileformat . artifactFix
+  endfunction
+endif
 
 " for airline plugin {{{3
 "========================================================================


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Vim9 script has been adopted for the `WebDevIconsGetFileFormatSymbol()` function.
This is a completely new Vim script and runs faster than the existing Vim script.
It also supports existing Vim scripts, and switches flexibly between them depending on the Vim version.
#### How should this be manually tested?

Please see github action's result.

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
