### PR TITLE
add icon for solidity with file extension .sol (using ether icon)

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -277,7 +277,8 @@ function! s:setDictionaries()
         \ 'xcplayground' : '',
         \ 'tex'      : 'ﭨ',
         \ 'r'        : 'ﳒ',
-        \ 'rproj'    : '鉶'
+        \ 'rproj'    : '鉶',
+        \ 'sol'      : 'ﲹ'
         \}
 
   let s:file_node_exact_matches = {

--- a/test/filetype.vim
+++ b/test/filetype.vim
@@ -211,6 +211,10 @@ function! s:suite.DartSymbol()
   call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.dart'), '')
 endfunction
 
+function! s:suite.SoliditySymbol()
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.sol'), 'ﲹ')
+endfunction
+
 function! s:suite.OverrideSymbol()
   set ft=vim
   call s:assert.equals(WebDevIconsGetFileTypeSymbol(), '')


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
This PR is to resolve  [#395](https://github.com/ryanoasis/vim-devicons/issues/395)

#### How should this be manually tested?

#### Any background context you can provide?
I noticed that there is no icons on Solidity files , so I searched for one in nerd fonts icons and chose the Ether icon since Solidity is the language for developing smart contracts on the Ethereum Virtual Machine 

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
![sol-vim](https://user-images.githubusercontent.com/63566771/124768039-da0dfb00-df27-11eb-9093-a6d524a6f770.png)