### PR TITLE
Use CSS Logo for CSS files

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -169,7 +169,7 @@ function! s:setDictionaries()
         \ 'slim'     : '',
         \ 'haml'     : '',
         \ 'ejs'      : '',
-        \ 'css'      : '',
+        \ 'css'      : '',
         \ 'less'     : '',
         \ 'md'       : '',
         \ 'mdx'      : '',


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Uses the CSS logo for CSS file types

#### How should this be manually tested?
Open a project with a CSS file and make sure the icon matches the icon of the cSS file in the screenshot

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/23138767/130146478-5e3c5874-90ed-47da-bcd4-c251b534d915.png)
