### PR TITLE
Modified function s:distro to check for FreeBSD Unix

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -117,6 +117,11 @@ function s:getDistro()
     endif
     return s:distro
   endif
+ " check for freeBSD
+  if system('uname -s') ==# "FreeBSD\n"
+    let s:distro = ''
+    return s:distro
+  endif
 
   let s:distro = ''
   return s:distro


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X ] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [ X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [ X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Display unix FreeBSB glyph when run on freebsd instead of the generic linux glyph 

#### How should this be manually tested?
Open it onto FreBSD
#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/3379936/130489497-e350d2b7-6b6a-4843-8573-51a29a39c082.png)
