### PR TITLE
Bsd feature

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -572,7 +572,7 @@ function! WebDevIconsGetFileFormatSymbol(...)
       let fileformat = ''
     else
       let fileformat = s:getDistro()
-	endif
+    endif
   elseif &fileformat ==? 'mac'
     let fileformat = ''
   endif

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -117,6 +117,11 @@ function s:getDistro()
     endif
     return s:distro
   endif
+ " check for freeBSD
+  if system('uname -s') ==# "FreeBSD\n"
+    let s:distro = ''
+    return s:distro
+  endif
 
   let s:distro = ''
   return s:distro

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -117,11 +117,6 @@ function s:getDistro()
     endif
     return s:distro
   endif
- " check for freeBSD
-  if system('uname -s') ==# "FreeBSD\n"
-    let s:distro = ''
-    return s:distro
-  endif
 
   let s:distro = ''
   return s:distro
@@ -571,6 +566,13 @@ function! WebDevIconsGetFileFormatSymbol(...)
     let fileformat = ''
   elseif &fileformat ==? 'unix'
     let fileformat = s:isDarwin() ? '' : s:getDistro()
+    if s:isDarwin()
+      let fileformat = '' 
+    elseif has('bsd')
+      let fileformat = ''
+    else
+      let fileformat = s:getDistro()
+	endif
   elseif &fileformat ==? 'mac'
     let fileformat = ''
   endif

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -565,7 +565,6 @@ function! WebDevIconsGetFileFormatSymbol(...)
   if &fileformat ==? 'dos'
     let fileformat = ''
   elseif &fileformat ==? 'unix'
-    let fileformat = s:isDarwin() ? '' : s:getDistro()
     if s:isDarwin()
       let fileformat = '' 
     elseif has('bsd')


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Display unix FreeBSB glyph when run on freebsd instead of the generic linux glyph

#### How should this be manually tested?
Launching *Vim on a BSD

#### Any background context you can provide?
First try, i modified s:getDistro that was a bad idea ; 
Second try, if check if there is "bsd" feature in case of unix fileformat.

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/3379936/130576292-5c23802a-51f2-4ec9-b800-2342cb3d6be3.png)
