### PR TITLE
[add] support for robots.txt

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -318,7 +318,8 @@ function! s:setDictionaries()
         \ 'config.ru'                        : '',
         \ 'gemfile'                          : '',
         \ 'makefile'                         : '',
-        \ 'cmakelists.txt'                   : ''
+        \ 'cmakelists.txt'                   : '',
+        \ 'robots.txt'                       : 'ﮧ'
         \}
 
   let s:file_node_pattern_matches = {


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Add support for robots.txt as mentioned in issue #318.
#### How should this be manually tested?
Create a robots.txt file and observe it's file icon in nerdtree.
Clone my fork and observe the change.
#### Any background context you can provide?
Icon used is from [this comment](https://github.com/ryanoasis/vim-devicons/issues/318#issuecomment-615255775)
#### What are the relevant tickets (if any)?
Issue #318 
#### Screenshots (if appropriate or helpful)
![image](https://user-images.githubusercontent.com/76893756/131322808-fe1dfdd2-6a34-4df3-bb94-8645b8a5cf5e.png)

One problem is this icon isn't supported by Cascadia Code. The above screenshot uses MesloLGF NF Regular font.