### PR TITLE
[fix] NERDTree automatic refresh #224

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -410,7 +410,7 @@ function! s:CursorHoldUpdate()
   endif
 
   " Do not update when a special buffer is selected
-  if !empty(&l:buftype) && &l:filetype != "nerdtree"
+  if !empty(&l:buftype) && &l:filetype !=# 'nerdtree'
     return
   endif
 

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -410,7 +410,7 @@ function! s:CursorHoldUpdate()
   endif
 
   " Do not update when a special buffer is selected
-  if !empty(&l:buftype)
+  if !empty(&l:buftype) && &l:filetype != "nerdtree"
     return
   endif
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/contributing.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

*Note*: The link to the Contributing Guidelines is broken.

#### What does this Pull Request (PR) do?
It fixes the bug reported in #224.

#### How should this be manually tested?
After applying this update, open NERDTree and create a new file. NERDTree will now automatically refresh and show the icon for the new file. 

#### Any background context you can provide?
NERDTree buffers have `buftype="nofile"`, so the `CursorHoldUpdate()` function will return prematurely when a NERDTree buffer is focused. This PR adds a `buftype` detection for NERDTree, preventing the return.

#### What are the relevant tickets (if any)?
#224 

