### PR TITLE
[fix] bsd feature in getdistro's function

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -98,6 +98,11 @@ function s:getDistro()
     return s:distro
   endif
 
+  if has('bsd')
+    let s:distro = ''
+    return s:distro
+  endif
+
   if g:DevIconsEnableDistro && executable('lsb_release')
     let s:lsb = system('lsb_release -i')
     if s:lsb =~# 'Arch'
@@ -567,13 +572,7 @@ function! WebDevIconsGetFileFormatSymbol(...)
   if &fileformat ==? 'dos'
     let fileformat = ''
   elseif &fileformat ==? 'unix'
-    if s:isDarwin()
-      let fileformat = '' 
-    elseif has('bsd')
-      let fileformat = ''
-    else
-      let fileformat = s:getDistro()
-    endif
+    let fileformat = s:isDarwin() ? '' : s:getDistro()
   elseif &fileformat ==? 'mac'
     let fileformat = ''
   endif


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

The function implemented in #410 is out of the responsibility of the function.
Originally, I think the Linux icon should be handled in the `s:getDistro()` function. 
This problem has been fixed.

#### How should this be manually tested?

#### Any background context you can provide?

- #410 

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)
