### PR TITLE
add .heex support

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -269,6 +269,7 @@ function! s:setDictionaries()
         \ 'exs'      : '',
         \ 'eex'      : '',
         \ 'leex'     : '',
+        \ 'heex'     : '',
         \ 'vim'      : '',
         \ 'ai'       : '',
         \ 'psd'      : '',

--- a/test/filetype.vim
+++ b/test/filetype.vim
@@ -170,7 +170,7 @@ function! s:suite.__OneArgument_CppIcon__()
 endfunction
 
 function! s:suite.__OneArgument_ElixirIcon__()
-  let targetfilenames = ['test.ex', 'test.exs', 'test.eex', 'test.leex']
+  let targetfilenames = ['test.ex', 'test.exs', 'test.eex', 'test.leex', 'test.heex']
   let expecticon = ''
   let child = themis#suite('OneArgument_ElixirIcon')
 


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
Shows elixir icon for .heex files

#### How should this be manually tested?
Open .heex file

#### Any background context you can provide?
Phoenix added new template language [link to the blogpost](https://phoenixframework.org/blog/phoenix-1.6-released)
