### PR TITLE
add Crystal support

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -188,6 +188,7 @@ function! s:setDictionaries()
         \ 'rb'       : '',
         \ 'gemspec'  : '',
         \ 'rake'     : '',
+        \ 'cr'       : '',
         \ 'php'      : '',
         \ 'py'       : '',
         \ 'pyc'      : '',

--- a/test/filetype.vim
+++ b/test/filetype.vim
@@ -29,6 +29,17 @@ function! s:suite.__OneArgument_RubyIcon__()
   endfor
 endfunction
 
+function! s:suite.__OneArgument_CrystalIcon__()
+  let targetfilenames = ['test.cr']
+  let expecticon = ''
+  let child = themis#suite('OneArgument_CrystalIcon')
+
+  for targetfilename in targetfilenames
+    let child[targetfilename] = funcref('s:Assert', [targetfilename, expecticon])
+  endfor
+endfunction
+
+
 function! s:suite.__OneArgument_MarkDownIcon__()
   let targetfilenames = ['test.md', 'test.markdown', 'test.mdx', 'test.rmd']
   let expecticon = ''


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Add icon for [Crystal programming language](https://github.com/crystal-lang/crystal)

#### How should this be manually tested?

Add to your `~/.vimrc`

```
let g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols['cr'] = ''
```

#### Any background context you can provide?

Nerd Fonts [2.2.0-RC](https://github.com/ryanoasis/nerd-fonts/tree/2.2.0-RC) is required

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/nerd-fonts/pull/429

#### Screenshots (if appropriate or helpful)

![image](https://user-images.githubusercontent.com/61285/163806524-20b00570-33d2-4ed7-b63b-8159815712dd.png)
![image](https://user-images.githubusercontent.com/61285/163806692-610f9fe7-8407-4817-b304-dae722972d45.png)


