### PR TITLE
[Fix] closing of collapsible directories in NERDTree plugin

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -257,28 +257,24 @@ function! WebDevIconsNERDTreeMapCloseChildren(node)
 endfunction
 
 function! WebDevIconsNERDTreeMapCloseDir(node)
-  " continue with normal original logic:
-  let parent = a:node.parent
-  while g:NERDTreeCascadeOpenSingleChildDir && !parent.isRoot()
-    let childNodes = parent.getVisibleChildren()
-    if len(childNodes) == 1 && childNodes[0].path.isDirectory
-      let parent = parent.parent
-    else
-      break
-    endif
+  let l:parent = a:node.parent
+  while l:parent.isCascadable()
+      let l:parent = l:parent.parent
   endwhile
-  if parent ==# {} || parent.isRoot()
-    call nerdtree#echo('cannot close tree root')
-  else
-    call parent.close()
-    " update the glyph
-    call WebDevIconsNERDTreeDirClose(parent)
-    call b:NERDTree.render()
-    call parent.putCursorHere(0, 0)
-    " glyph change possible artifact clean-up
-    if g:DevIconsEnableNERDTreeRedraw ==# 1
-      redraw!
-    endif
+
+  if l:parent.isRoot()
+      call nerdtree#echo('cannot close tree root')
+      return
+  endif
+
+  call parent.close()
+  " update the glyph
+  call WebDevIconsNERDTreeDirClose(parent)
+  call b:NERDTree.render()
+  call parent.putCursorHere(0, 0)
+  " glyph change possible artifact clean-up
+  if g:DevIconsEnableNERDTreeRedraw ==# 1
+    redraw!
   endif
 endfunction
 


### PR DESCRIPTION
The NERDTree plugin will under some conditions fail to close a collapisble directory with the error message: "cannot close tree root". This commit replaces the traversing logic for collapsible directories when closing with the latest code from NERDTree.

To reproduce this error use `g:NERDTreeCascadeSingleChildDir=0` and `g:NERDTreeCascadeOpenSingleChildDir=1`. Then the following directory tree:

```
dir-a
    dir-b
        dir-c
dir-d
```

Go over `dir-c` and press "x" to close this node.

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)
