### PR TITLE
Allow custom distro icon

### DIFF
--- a/doc/webdevicons.txt
+++ b/doc/webdevicons.txt
@@ -679,6 +679,11 @@ Character Mappings ~
 <
 
 >
+  " configure the icon to be used for your OS/Linux distribution
+  let g:WebDevIconsDistro = ''
+<
+
+>
   " enable custom folder/directory glyph exact matching
   " (enabled by default when g:WebDevIconsUnicodeDecorateFolderNodes is set to 1)
   let WebDevIconsUnicodeDecorateFolderNodesExactMatches = 1

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -97,6 +97,11 @@ function s:getDistro()
   if exists('s:distro')
     return s:distro
   endif
+  
+  if exists('g:WebDevIconsDistro') && g:WebDevIconsDistro != ''
+    let s:distro = g:WebDevIconsDistro
+    return s:distro
+  endif
 
   if has('bsd')
     let s:distro = ''

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -122,6 +122,8 @@ function s:getDistro()
       let s:distro = ''
     elseif s:lsb =~# 'Dock'
       let s:distro = ''
+    elseif s:lsb =~# 'Manjaro'
+      let s:distro = ''
     else
       let s:distro = ''
     endif


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Adds a configuration variable, `g:WebDevIconsDistro` to allow users to specify their distribution's icon. Several popular distributions are not supported "out of the box" by this plugin, i.e., Fedora, Suse Linux, etc. This PR also adds my particular distro: Manjaro Linux.

#### How should this be manually tested?

I use vim-plug as my vim plugin manager. I have vim-devicons plugin listed last, as directed.
I use `let g:WebDevIconsDistro = "\uF30B"` in my `.vimrc` to force vim-devicons to use my selected icon. This produced the following result:

![image](https://user-images.githubusercontent.com/6895593/218386638-4731d5f3-4073-432f-a64e-23045e8bd29d.png)

Next, I removed the custom distro icon setting from my `.vimrc` to test that the addition of Manjaro as a detected Linux distribution is working. This resulted in:

![image](https://user-images.githubusercontent.com/6895593/218386858-fae7cc31-c11f-410f-a0b0-966c42511960.png)

#### Any background context you can provide?

N/A

#### What are the relevant tickets (if any)?

Fixes #445

#### Screenshots (if appropriate or helpful)

N/A