### PR TITLE
Add zig icon

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -286,7 +286,8 @@ function! s:setDictionaries()
         \ 'r'        : 'ﳒ',
         \ 'rproj'    : '鉶',
         \ 'sol'      : 'ﲹ',
-        \ 'pem'      : ''
+        \ 'pem'      : '',
+        \ 'zig'      : '',
         \}
 
   let s:file_node_exact_matches = {

--- a/test/filetype.vim
+++ b/test/filetype.vim
@@ -287,6 +287,10 @@ function! s:suite.OneArgument_PemIcon()
   call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.pem'), '')
 endfunction
 
+function! s:suite.OneArgument_GetZigIcon()
+  call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.zig'), '')
+endfunction
+
 function! s:suite.TwoArgument_zero_GetFileIcon()
   call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.vim', 0), '')
 endfunction


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
This pull request adds icon for [zig](https://ziglang.org/) source codes

#### How should this be manually tested?
Opening a file with .zig extension

#### Any background context you can provide?
Zig is a general-purpose programming language. More can be found about zig here <https://ziglang.org/>

#### What are the relevant tickets (if any)?
None

#### Screenshots (if appropriate or helpful)
![Screenshot_20230526_171434](https://github.com/ryanoasis/vim-devicons/assets/16154204/1667d1c5-d15e-47c1-8478-7a9a9a773072)