### PR TITLE
Updating obsolete material design icons

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -217,7 +217,7 @@ function! s:setDictionaries()
         \ 'cc'       : '',
         \ 'cp'       : '',
         \ 'c'        : '',
-        \ 'cs'       : '',
+        \ 'cs'       : '󰌛',
         \ 'h'        : '',
         \ 'hh'       : '',
         \ 'hpp'      : '',
@@ -278,15 +278,15 @@ function! s:setDictionaries()
         \ 'tsx'      : '',
         \ 'jl'       : '',
         \ 'pp'       : '',
-        \ 'vue'      : '﵂',
+        \ 'vue'      : '󰡄',
         \ 'elm'      : '',
         \ 'swift'    : '',
         \ 'xcplayground' : '',
-        \ 'tex'      : 'ﭨ',
-        \ 'r'        : 'ﳒ',
-        \ 'rproj'    : '鉶',
-        \ 'sol'      : 'ﲹ',
-        \ 'pem'      : ''
+        \ 'tex'      : '󰙩',
+        \ 'r'        : '󰟔',
+        \ 'rproj'    : '󰗆',
+        \ 'sol'      : '󰡪',
+        \ 'pem'      : '󰌋'
         \}
 
   let s:file_node_exact_matches = {
@@ -326,7 +326,7 @@ function! s:setDictionaries()
         \ 'gemfile'                          : '',
         \ 'makefile'                         : '',
         \ 'cmakelists.txt'                   : '',
-        \ 'robots.txt'                       : 'ﮧ'
+        \ 'robots.txt'                       : '󰚩'
         \}
 
   let s:file_node_pattern_matches = {

--- a/test/filetype.vim
+++ b/test/filetype.vim
@@ -208,7 +208,7 @@ function! s:suite.OneArgument_GetTypeScriptIcon()
 endfunction
 
 function! s:suite.OneArgument_GetVueIcon()
-  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.vue'), '﵂')
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.vue'), '󰡄')
 endfunction
 
 function! s:suite.OneArgument_GetNodeModuleIcon()
@@ -220,7 +220,7 @@ function! s:suite.OneArgument_GetDropboxIcon()
 endfunction
 
 function! s:suite.OneArgument_GetRIcon()
-  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.r'), 'ﳒ')
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.r'), '󰟔')
 endfunction
 
 function! s:suite.OneArgument_GetLuaIcon()
@@ -236,11 +236,11 @@ function! s:suite.OneArgument_GetCIcon()
 endfunction
 
 function! s:suite.OneArgument_GetCSSIcon()
-  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.cs'), '')
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.cs'), '󰌛')
 endfunction
 
 function! s:suite.OneArgument_GetCSharpIcon()
-  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.cs'), '')
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.cs'), '󰌛')
 endfunction
 
 function! s:suite.OneArgument_GetElmIcon()
@@ -256,7 +256,7 @@ function! s:suite.OneArgument_GetDartIcon()
 endfunction
 
 function! s:suite.OneArgument_GetSolidityIcon()
-  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.sol'), 'ﲹ')
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.sol'), '󰡪')
 endfunction
 
 function! s:suite.OneArgument_GetGoIcon()
@@ -272,7 +272,7 @@ function! s:suite.OneArgument_GetScalaIcon()
 endfunction
 
 function! s:suite.OneArgument_GetTexIcon()
-  call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.tex'), 'ﭨ')
+  call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.tex'), '󰙩')
 endfunction
 
 function! s:suite.OneArgument_GetLicenseIcon()
@@ -280,11 +280,11 @@ function! s:suite.OneArgument_GetLicenseIcon()
 endfunction
 
 function! s:suite.OneArgument_GetRobotIcon()
-  call s:assert.equals( WebDevIconsGetFileTypeSymbol('robots.txt'), 'ﮧ')
+  call s:assert.equals( WebDevIconsGetFileTypeSymbol('robots.txt'), '󰚩')
 endfunction
 
 function! s:suite.OneArgument_PemIcon()
-  call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.pem'), '')
+  call s:assert.equals( WebDevIconsGetFileTypeSymbol('test.pem'), '󰌋')
 endfunction
 
 function! s:suite.TwoArgument_zero_GetFileIcon()


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [X] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [X] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [X] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?
This PR updates the material design icon codepoints.

#### How should this be manually tested?
Clone the fork and check that the new icons are good.

#### Any background context you can provide?
With Release v3.0.0 the Material Design Icons were updated and moved to new codepoints (reasons for that are in the release notes).

#### What are the relevant tickets (if any)?
Fixes #452
#### Screenshots (if appropriate or helpful)
![Screenshot](https://i.imgur.com/RPXJrxm.png)