### PR TITLE
Add Svelte support (#415).

### DIFF
--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -286,6 +286,7 @@ function! s:setDictionaries()
         \ 'r'        : 'ﳒ',
         \ 'rproj'    : '鉶',
         \ 'sol'      : 'ﲹ',
+        \ 'svelte'   : '',
         \ 'pem'      : ''
         \}
 

--- a/test/filetype.vim
+++ b/test/filetype.vim
@@ -259,6 +259,10 @@ function! s:suite.OneArgument_GetSolidityIcon()
   call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.sol'), 'ﲹ')
 endfunction
 
+function! s:suite.OneArgument_GetSvelteIcon()
+  call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.svelte'), '')
+endfunction
+
 function! s:suite.OneArgument_GetGoIcon()
   call s:assert.equals(WebDevIconsGetFileTypeSymbol('test.go'), '')
 endfunction


### PR DESCRIPTION
#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

Adds support for [Svelte](https://svelte.dev/) icons as discussed here: https://github.com/ryanoasis/vim-devicons/issues/415

#### How should this be manually tested?

Open a project with `.svelte` files in filebrowser like NERDtree and confirm that the Svelte project icon is loaded.

#### Any background context you can provide?

Svelte is a popular web UI framework like React and Vue. I obtained the icon by looking up "svelte" here: https://www.nerdfonts.com/cheat-sheet

#### What are the relevant tickets (if any)?

https://github.com/ryanoasis/vim-devicons/issues/415

#### Screenshots (if appropriate or helpful)

![Screenshot from 2024-05-09 10-03-12](https://github.com/ryanoasis/vim-devicons/assets/5913244/c68aad39-21af-4908-a826-1215607f6f44)
![Screenshot from 2024-05-09 10-02-38](https://github.com/ryanoasis/vim-devicons/assets/5913244/2a621d7e-6db5-46c3-a53a-52e543f07f34)

