### PR TITLE
add symbol for noeol

### DIFF
--- a/doc/webdevicons.txt
+++ b/doc/webdevicons.txt
@@ -651,7 +651,13 @@ Character Mappings ~
   " set a byte character marker (BOM) utf-8 symbol when retrieving file encoding
   " disabled by default with no value
   let g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol = ''
-<
+
+
+
+  " set a noendofline symbol when retrieving file format
+  " disabled by default with no value
+  let g:WebDevIconsNoEndOfLineDefaultSymbol = '󰭜'
+
 
 >
   " enable folder/directory glyph flag (disabled by default with 0)

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -82,6 +82,7 @@ call s:set('g:WebDevIconsTabAirLineAfterGlyphPadding', '')
 
 call s:set('g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol', '')
 call s:set('g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol', '')
+call s:set('g:WebDevIconsNoEndOfLineDefaultSymbol', '')
 call s:set('g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol', g:DevIconsEnableFoldersOpenClose ? '' : '')
 call s:set('g:WebDevIconsUnicodeDecorateFolderNodesSymlinkSymbol',  '')
 call s:set('g:DevIconsDefaultFolderOpenSymbol', '')
@@ -565,9 +566,14 @@ endfunction
 function! WebDevIconsGetFileFormatSymbol(...)
   let fileformat = ''
   let bomb = ''
+  let noeolf = ''
 
   if (&bomb && g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol !=? '')
     let bomb = g:WebDevIconsUnicodeByteOrderMarkerDefaultSymbol . ' '
+  endif
+
+  if (!&eol && g:WebDevIconsNoEndOfLineDefaultSymbol !=? '')
+    let noeolf = g:WebDevIconsNoEndOfLineDefaultSymbol . ' '
   endif
 
   if &fileformat ==? 'dos'
@@ -580,7 +586,7 @@ function! WebDevIconsGetFileFormatSymbol(...)
 
   let artifactFix = s:DevIconsGetArtifactFix()
 
-  return bomb . fileformat . artifactFix
+  return bomb . noeolf . fileformat . artifactFix
 endfunction
 
 " for airline plugin {{{3


### PR DESCRIPTION
only show this symbol when g:WebDevIconsNoEndOfLineDefaultSymbol is configured

#### Requirements (please check off with 'x')

- [x] I have read the [Contributing Guidelines](https://github.com/ryanoasis/vim-devicons/blob/master/CONTRIBUTING.md)
- [x] I have read or at least glanced at the [FAQ](https://github.com/ryanoasis/vim-devicons#faq--troubleshooting)
- [x] I have read or at least glanced at the [Wiki](https://github.com/ryanoasis/vim-devicons/wiki)

#### What does this Pull Request (PR) do?

show symbol for noeol status as the airline [!EOL]

#### How should this be manually tested?

## when g:WebDevIconsNoEndOfLineDefaultSymbol is default configured

1. open a simple file in vim
2. change eof status by vim command ":set noendofline"
3. there should be no symbol for noeof on airline fileformat part

## when g:WebDevIconsNoEndOfLineDefaultSymbol is configured by user

buffer verify

1. set g:WebDevIconsNoEndOfLineDefaultSymbol in vimrc
2. open a simple file in vim
3. change eof status by vim command ":set noendofline"
4. airline fileformat part should contain the value of "g:WebDevIconsNoEndOfLineDefaultSymbol" 

file verify

1. set g:WebDevIconsNoEndOfLineDefaultSymbol in vimrc
2. create a simple file:  echo "hello" > abc
3. open file in binary mode: vim -b abc
4. call vim command ":set noendofline", then save and exit
5. open file in normal mode: vim abc
6. airline fileformat part should contain the value of "g:WebDevIconsNoEndOfLineDefaultSymbol" 

#### Any background context you can provide?

#### What are the relevant tickets (if any)?

#### Screenshots (if appropriate or helpful)

![Untitled](https://github.com/user-attachments/assets/ea5bc733-bc17-43b7-8b71-ad7d3a6a47d1)
